### PR TITLE
add gitea ci to build api, fetcher and tele images

### DIFF
--- a/.gitea/workflows/build-docker.yml
+++ b/.gitea/workflows/build-docker.yml
@@ -1,0 +1,83 @@
+name: Build Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  REGISTRY: git.thuanle.me
+  IMAGE_NAMESPACE: public
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - arm64
+        service:
+          - api
+          - fetcher
+          - tele
+    runs-on: ${{ matrix.arch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history so commit count is accurate
+
+      - name: Get commit metadata
+        run: |
+          echo "COMMIT_COUNT=$(git rev-list --count HEAD)" >> "$GITHUB_ENV"
+          echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+
+      - name: Login to Docker Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build Docker image
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/cse-mark-${{ matrix.service }}"
+          echo "Building $IMAGE for ${{ matrix.arch }}"
+
+          docker build \
+            -f Dockerfile_${{ matrix.service }} \
+            -t "${IMAGE}:${{ matrix.arch }}-latest" \
+            --label "version=${{ env.COMMIT_COUNT }}" \
+            --label "commit_sha=${{ env.COMMIT_SHA }}" \
+            --label "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            .
+
+          docker push "${IMAGE}:${{ matrix.arch }}-latest"
+
+  manifest:
+    strategy:
+      matrix:
+        service:
+          - api
+          - fetcher
+          - tele
+    runs-on: linux
+    needs: [build]
+    steps:
+      - name: Login to Docker Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push multi-arch Docker manifest
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/cse-mark-${{ matrix.service }}"
+
+          # Combine the per-arch images into a single multi-arch :latest tag
+          docker manifest rm "${IMAGE}:latest" || true
+          docker manifest create "${IMAGE}:latest" \
+            "${IMAGE}:amd64-latest" \
+            "${IMAGE}:arm64-latest"
+          docker manifest push "${IMAGE}:latest"


### PR DESCRIPTION
Adds .gitea/workflows/build-docker.yml building the three service images (cse-mark-api, cse-mark-fetcher, cse-mark-tele) for amd64 and arm64 on push to main, then publishing a multi-arch :latest manifest to the public registry namespace. Follows the tl-proxy multi-service build pattern.